### PR TITLE
Export common.toFetch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import {
   XhrResponse
 } from "./browser";
 
+export { toFetch } from "./common";
+
 export * from "servie/dist/signal";
 export * from "servie/dist/headers";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,7 @@ import {
   XhrResponse
 } from "./browser";
 
-export { toFetch } from "./common";
-
+export * from "./common";
 export * from "servie/dist/signal";
 export * from "servie/dist/headers";
 


### PR DESCRIPTION
Hi! Thank you for a nice lib.
If this PR is ok, please release this change asap because it blocks upgrading popsicle version in multiple of our libs.

Readme [section Customization says](https://github.com/serviejs/popsicle#customization): 
> Build the functionality you require by composing middleware functions and using `toFetch`. See `src/node.ts` for an example.

But it's impossible to do because `toFetch` is not exported. I've tested it using node v12.5.0.
Before:
```node
> require('popsicle')
{
  Signal: [Function: Signal],
  AbortController: [Function: AbortController],
  Headers: [Function: Headers],
  fetch: [Function: fetch],
  middleware: [Function: composedDebug]
}
```

After this pr:
```node
> require('popsicle')
{
  toFetch: [Function: toFetch],
  Signal: [Function: Signal],
  AbortController: [Function: AbortController],
  Headers: [Function: Headers],
  fetch: [Function: fetch],
  middleware: [Function: composedDebug]
}
```